### PR TITLE
fix: NGINX URLs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ A collaborative list of awesome proxy servers and resources. Feel free to contri
 
 ### Popular Reverse Proxies
 
-- [Nginx](http://nginx.net/)
+- [NGINX Open Source](https://nginx.org/) / [NGINX Plus](https://nginx.com/)
 - [Apache](http://wiki.apache.org/cocoon/ApacheModProxy)
 - [HAProxy](http://haproxy.1wt.eu/)
 - [Caddy](https://caddyserver.com/docs/proxy)


### PR DESCRIPTION
Hi,

nginx.net redirects to nginx.org anyway. And I think it's nice to give people the commercial option of NGINX. 

I hope this makes sense and thanks in advance!

Best,
G.