### PR TITLE
Added YARP and Sōzu reverse proxies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Sponsored By: <a href="https://altern.ai">Altern, List of AI tools and resources
 - [ngrok](https://github.com/inconshreveable/ngrok)
 - [Pipy](https://flomesh.io/pipy/)
 - [YARP](https://microsoft.github.io/reverse-proxy/)
+- [Sōzu](https://www.sozu.io)
 
 ## SOCKS Proxy
 

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Sponsored By: <a href="https://altern.ai">Altern, List of AI tools and resources
 - [relayd](https://bsd.plumbing/)
 - [ngrok](https://github.com/inconshreveable/ngrok)
 - [Pipy](https://flomesh.io/pipy/)
+- [YARP](https://microsoft.github.io/reverse-proxy/)
 
 ## SOCKS Proxy
 


### PR DESCRIPTION
As in title, added [YARP](https://microsoft.github.io/reverse-proxy/) and [Sōzu](https://www.sozu.io) reverse proxies.
