### PR TITLE
Add Heroshot - screenshot automation for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,166 @@
+# Awesome DevTools
+
+> A curated list of awesome developer tools and services — from cloud platforms and IDEs to AI-powered coding assistants and productivity utilities.
+
+Inspired by [awesome](https://github.com/sindresorhus/awesome).
+
+## Table of Contents
+
+* [Analytics Tools](#analytics-tools)
+* [Cloud Platforms](#cloud-platforms)
+* [AI Coding Tools](#ai-coding-tools)
+* [IDEs & Code Editors](#ides--code-editors)
+* [CLIs & Terminal Tools](#clis--terminal-tools)
+* [DevOps & Infrastructure](#devops--infrastructure)
+* [APIs & Backends](#apis--backends)
+* [Design & UI Tools](#design--ui-tools)
+* [Testing & Quality](#testing--quality)
+* [Docs & Knowledge](#docs--knowledge)
+* [Browser Extensions](#browser-extensions)
+* [Productivity & Misc](#productivity--misc)
+* [Database Migrations & DevOps](#database-migration--devops)
+
+---
+
+## Analytics Tools
+
+- [Plausible](https://plausible.io/) - Easy to use and privacy-friendly Google Analytics alternative.
+- [Repohistory](https://repohistory.com) - GitHub repo analytics tool without 14 days limit.
+- [umami](https://umami.is/) - Umami is an open source, privacy-focused alternative to Google Analytics.
+
+## Cloud Platforms
+
+* [Vercel](https://vercel.com/) - Frontend cloud for static sites and serverless functions.
+* [Netlify](https://www.netlify.com/) - All-in-one platform for automating modern web projects.
+* [AWS](https://aws.amazon.com/) - Comprehensive cloud computing services platform.
+* [Google Cloud Platform](https://cloud.google.com/) - Scalable and secure cloud infrastructure.
+* [Azure](https://azure.microsoft.com/) - Microsoft’s cloud computing platform.
+* [DigitalOcean](https://www.digitalocean.com/) - Developer-friendly cloud for small apps.
+* [Render](https://render.com/) - Unified cloud to build and run apps with ease.
+
+## AI Coding Tools
+
+* [Cursor](https://www.cursor.so/) - AI-powered code editor with native GPT integration.
+* [GitHub Copilot](https://github.com/features/copilot) - AI pair programmer powered by OpenAI.
+* [Windsurf](https://windsurf.com/) - Free AI-powered code autocomplete.
+* [Tabnine](https://www.tabnine.com/) - AI code completions trained on open-source code.
+* [Cody (Sourcegraph)](https://sourcegraph.com/cody) - AI coding assistant with codebase context.
+* [Amazon CodeWhisperer](https://aws.amazon.com/codewhisperer/) - AI-powered code suggestions from AWS.
+* [Claude Code](https://claude.ai/code) - Anthropic's official CLI for Claude.
+* [Cline](https://github.com/cline/cline) - AI-powered code assistant.
+* [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal.
+* [Kodus](https://kodus.io/) - Open-source AI code-review tool.
+
+## IDEs & Code Editors
+
+* [VSCode](https://code.visualstudio.com/) - Popular, extensible open-source editor by Microsoft.
+* [IntelliJ IDEA](https://www.jetbrains.com/idea/) - Powerful IDE for JVM and polyglot development.
+* [WebStorm](https://www.jetbrains.com/webstorm/) - IDE for JavaScript and web development.
+* [Neovim](https://neovim.io/) - Modernized Vim for advanced editing.
+* [Sublime Text](https://www.sublimetext.com/) - Lightweight, fast code editor.
+* [Fleet](https://www.jetbrains.com/fleet/) - Collaborative, lightweight IDE by JetBrains.
+
+## CLIs & Terminal Tools
+
+* [Fig](https://fig.io/) - Autocomplete and UI enhancements for your terminal.
+* [Warp](https://www.warp.dev/) - Modern, Rust-based terminal with AI commands.
+* [tldr](https://tldr.sh/) - Simplified man pages for command-line tools.
+* [fzf](https://github.com/junegunn/fzf) - Fuzzy finder for terminal power users.
+* [exa](https://the.exa.website/) - Modern replacement for `ls` with icons and colors.
+* [bat](https://github.com/sharkdp/bat) - Cat clone with syntax highlighting.
+* [zx](https://github.com/google/zx) - Tool for writing shell scripts in JavaScript.
+* [ccr](https://github.com/NeverVane/commandchronicles) - Enhanced CLI history manager, project-aware, with sync and encryption.
+* [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets with dynamic completions and AI integration.
+
+## DevOps & Infrastructure
+
+* [Docker](https://www.docker.com/) - Container platform for building and running apps.
+* [Kubernetes](https://kubernetes.io/) - Container orchestration system.
+* [Terraform](https://www.terraform.io/) - Infrastructure as code tool by HashiCorp.
+* [Pulumi](https://www.pulumi.com/) - IaC tool using real programming languages.
+* [GitHub Actions](https://github.com/features/actions) - CI/CD pipelines natively in GitHub.
+* [CircleCI](https://circleci.com/) - Continuous integration and delivery platform.
+* [Jenkins](https://www.jenkins.io/) - Open-source automation server.
+* [Ansible](https://www.ansible.com/) - Configuration management and automation tool.
+* [DeployHQ](https://www.deployhq.com/) - Modern, web-based deployment platform.
+* [Buildstash](https://buildstash.com/) - Binary and release management platform for built software.
+
+## APIs & Backends
+
+* [Firebase](https://firebase.google.com/) - Google’s BaaS for realtime apps.
+* [Supabase](https://supabase.com/) - Open-source Firebase alternative.
+* [Hasura](https://hasura.io/) - Instant GraphQL APIs on your data.
+* [PocketBase](https://pocketbase.io/) - Lightweight local backend with realtime and auth.
+* [Appwrite](https://appwrite.io/) - Secure backend server for web and mobile apps.
+* [Strapi](https://strapi.io/) - Open-source headless CMS.
+* [Directus](https://directus.io/) - Real-time data platform and CMS.
+* [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
+* [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
+
+## Design & UI Tools
+
+* [Figma](https://www.figma.com/) - Collaborative interface design tool.
+* [Penpot](https://penpot.app/) - Open-source design and prototyping platform.
+* [Storybook](https://storybook.js.org/) - UI component explorer for frontend teams.
+* [Radix UI](https://www.radix-ui.com/) - Primitives for building high-quality UI components.
+* [Tailwind CSS](https://tailwindcss.com/) - Utility-first CSS framework.
+* [Material UI](https://mui.com/) - React UI framework with Google's Material Design.
+* [Chakra UI](https://chakra-ui.com/) - Modular, accessible component library for React.
+
+## Testing & Quality
+
+* [Jest](https://jestjs.io/) - Delightful JavaScript testing framework.
+* [Playwright](https://playwright.dev/) - End-to-end testing for modern web apps.
+* [Cypress](https://www.cypress.io/) - Fast, easy testing for anything that runs in a browser.
+* [Vitest](https://vitest.dev/) - Vite-native unit test framework.
+* [ESLint](https://eslint.org/) - Linting utility for JavaScript and TypeScript.
+* [Prettier](https://prettier.io/) - Opinionated code formatter.
+* [SonarQube](https://www.sonarsource.com/products/sonarqube/) - Continuous inspection of code quality.
+
+## Docs & Knowledge
+
+* [Docusaurus](https://docusaurus.io/) - Easy-to-maintain open-source documentation site generator.
+* [Notion](https://www.notion.so/) - All-in-one workspace for notes and collaboration.
+* [GitBook](https://www.gitbook.com/) - Knowledge management and docs platform.
+* [ReadMe](https://readme.com/) - Interactive API documentation builder.
+* [Obsidian](https://obsidian.md/) - Markdown-based knowledge base and note-taking tool.
+* [Logseq](https://logseq.com/) - Local-first, plain text knowledge management system.
+* [xyd](https://xyd.dev/) - A new scalable Open Source Docs Framework for future dev powered by LiveSession.
+* [Heroshot](https://heroshot.sh/) - Screenshot automation CLI for docs. Define screenshots once, regenerate with one command.
+
+## Browser Extensions
+
+* [React Developer Tools](https://github.com/facebook/react-devtools) - Inspect React component hierarchies.
+* [Redux DevTools](https://github.com/reduxjs/redux-devtools) - Time-traveling debugger for Redux.
+* [Wappalyzer](https://www.wappalyzer.com/) - Identify technologies used on websites.
+* [Octotree](https://www.octotree.io/) - GitHub code tree browser extension.
+* [Web Developer](https://github.com/chrispederick/web-developer) - Adds developer tools to your browser.
+* [JSON Viewer](https://jsonviewer.io/) - Format and view JSON in the browser.
+
+## Productivity & Misc
+
+* [Raycast](https://www.raycast.com/) - Mac launcher for dev productivity.
+* [Linear](https://linear.app/) - Issue tracking built for modern teams.
+* [Cron](https://cron.com/) - Next-gen calendar app for professionals.
+* [Alfred](https://www.alfredapp.com/) - Mac productivity app for quick actions.
+* [Notion](https://www.notion.so/) - Workspace for notes, docs, and tasks.
+* [Loom](https://www.loom.com/) - Video messaging for work.
+* [Miro](https://miro.com/) - Online whiteboard for collaboration.
+* [Hopp](https://gethopp.app/) - Open source remote pair programming app.
+* [Digital Toolpad](https://www.DigitalToolpad.com) - Modern suite of dev tools that run 100% offline. No Cloud or Data transfer, providing pure privacy for individual or corporate use.
+
+## Database Migration & DevOps
+* [Liquibase](https://www.liquibase.org/) - Open-source database schema change management with multi-database support.
+* [Flyway](https://flywaydb.org/) - Lightweight, SQL-based database version control and migration tool.
+* [Bytebase](https://www.bytebase.com/) - Database DevOps platform with GitOps and safe schema change workflows.
+* [Sqitch](https://sqitch.org/) - Database-native change management using plain SQL scripts and dependency tracking.
+* [DBT](https://www.getdbt.com/) - Transform data in your warehouse with version-controlled SQL pipelines.
+
+### Related Lists
+
+- [Awesome AI Coding Tools  ](https://github.com/tokyo-dal/awesome-ai-coding-tools) - A curated list of AI-powered coding tools
+
+---
+
+PRs welcome!
+


### PR DESCRIPTION
Adds [Heroshot](https://heroshot.sh/) to the Docs & Knowledge section.

**What it does:** Screenshot automation CLI for documentation. Define screenshots with a visual element picker, regenerate them all with one command.

**Why it fits:** Complements docs tools like Docusaurus and GitBook by automating the tedious task of keeping documentation screenshots up to date.

**Links:**
- GitHub: https://github.com/omachala/heroshot
- npm: https://www.npmjs.com/package/heroshot
- Docs: https://heroshot.sh