### PR TITLE
Add Agent Gateway to APIs & Backends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
+* [Agent Gateway](https://agent-gateway-kappa.vercel.app) - Pay-as-you-go API gateway giving AI agents access to 34+ services: wallets, trading, storage, scheduling, scraping, and more. One API key, USDC billing on Base.
 
 ## Design & UI Tools
 


### PR DESCRIPTION
## What

Adds [Agent Gateway](https://agent-gateway-kappa.vercel.app) to the **APIs & Backends** section.

## Why

Agent Gateway is a unified API gateway that gives AI agents (and developers) pay-as-you-go access to 34+ production-ready services — wallets, perpetual trading, file storage, scheduling, scraping, screenshot capture, email, DNS, and more — through a single API key. Billing is in USDC on Base (pay for what you use, no subscriptions).

It fits alongside Postman and Hive Intelligence in the AI agent tooling space but covers infrastructure services rather than data.

## Links

- Landing: https://agent-gateway-kappa.vercel.app
- OpenAPI spec: https://agent-gateway-kappa.vercel.app/openapi.json
- Agent manifest: https://agent-gateway-kappa.vercel.app/.well-known/agent.json