### PR TITLE
Add brood-box to AI Coding Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Netlify](https://www.netlify.com/) - All-in-one platform for automating modern web projects.
 * [AWS](https://aws.amazon.com/) - Comprehensive cloud computing services platform.
 * [Google Cloud Platform](https://cloud.google.com/) - Scalable and secure cloud infrastructure.
-* [Azure](https://azure.microsoft.com/) - Microsoft’s cloud computing platform.
+* [Azure](https://azure.microsoft.com/) - Microsoft's cloud computing platform.
 * [DigitalOcean](https://www.digitalocean.com/) - Developer-friendly cloud for small apps.
 * [Render](https://render.com/) - Unified cloud to build and run apps with ease.
 
@@ -50,6 +50,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Cline](https://github.com/cline/cline) - AI-powered code assistant.
 * [OpenCode](https://opencode.ai/) - AI coding agent built for the terminal.
 * [Kodus](https://kodus.io/) - Open-source AI code-review tool.
+* [brood-box](https://github.com/stacklok/brood-box) - Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation and egress control.
 
 ## IDEs & Code Editors
 
@@ -87,7 +88,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 
 ## APIs & Backends
 
-* [Firebase](https://firebase.google.com/) - Google’s BaaS for realtime apps.
+* [Firebase](https://firebase.google.com/) - Google's BaaS for realtime apps.
 * [Supabase](https://supabase.com/) - Open-source Firebase alternative.
 * [Hasura](https://hasura.io/) - Instant GraphQL APIs on your data.
 * [PocketBase](https://pocketbase.io/) - Lightweight local backend with realtime and auth.
@@ -162,4 +163,3 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 ---
 
 PRs welcome!
-


### PR DESCRIPTION
## Summary

* Add [brood-box](https://github.com/stacklok/brood-box) to the **AI Coding Tools** section.
* brood-box is a CLI tool that runs coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation and egress control.

🤖 Generated with [Claude Code](https://claude.ai/code) and [Brood Box](https://github.com/stacklok/brood-box)