### PR TITLE
Add LinkMeta to APIs & Backends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
+* [LinkMeta](https://linkmeta.dev/) - Free URL metadata extraction API for developers.
 
 ## Design & UI Tools
 


### PR DESCRIPTION
## Summary

- Add [LinkMeta](https://linkmeta.dev/) to the **APIs & Backends** section
- LinkMeta is a free URL metadata extraction API for developers — extract titles, descriptions, images, and Open Graph data from any URL

## Why it belongs here

LinkMeta provides a free-forever API that developers can use to fetch rich metadata from URLs, useful for link previews, SEO tools, and social sharing features.