### PR TITLE
Add PageShot to APIs & Backends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
+* [PageShot](https://pageshot.site/) - Free screenshot and web page capture API for developers.
 
 ## Design & UI Tools
 


### PR DESCRIPTION
## Summary

- Add [PageShot](https://pageshot.site/) to the **APIs & Backends** section
- PageShot is a free screenshot and web page capture API for developers — capture full-page screenshots and page snapshots programmatically

## Why it belongs here

PageShot provides a free-forever API for capturing screenshots and web page content, useful for monitoring, testing, and content archival.