### PR TITLE
Add PDFSpark to APIs & Backends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
+* [PDFSpark](https://pdfspark.dev/) - Free HTML and URL to PDF conversion API for developers.
 
 ## Design & UI Tools
 


### PR DESCRIPTION
## Summary

- Add [PDFSpark](https://pdfspark.dev/) to the **APIs & Backends** section
- PDFSpark is a free HTML and URL to PDF conversion API for developers — generate PDFs from HTML content or web pages via a simple API call

## Why it belongs here

PDFSpark provides a free-forever API for converting HTML and URLs to PDF documents, useful for report generation, invoicing, and document workflows.