### PR TITLE
Add LinkShrink to APIs & Backends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
+* [LinkShrink](https://linkshrink.dev/) - Free privacy-first URL shortener API for developers.
 
 ## Design & UI Tools
 


### PR DESCRIPTION
## Summary

- Add [LinkShrink](https://linkshrink.dev/) to the **APIs & Backends** section
- LinkShrink is a free privacy-first URL shortener API for developers — shorten URLs programmatically with no tracking or analytics overhead

## Why it belongs here

LinkShrink provides a free-forever, privacy-focused URL shortener API, useful for applications that need link shortening without compromising user privacy.