### PR TITLE
Add KeyboardTester.click Online Ruler — actual-size on-screen ruler

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,3 +163,4 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 
 PRs welcome!
 
+- [KeyboardTester.click Online Ruler](https://keyboardtester.click/online-ruler.php) - Free browser SVG ruler in actual size (cm + inches), calibrate with credit card or DPI. Useful for verifying physical dimensions on screen.


### PR DESCRIPTION
Adds a useful browser-based developer utility:

**Online Ruler** (https://keyboardtester.click/online-ruler.php) - SVG ruler in actual size (cm + inches) on any screen. Calibrate via credit card overlay (ISO ID-1, 85.6 x 54 mm) or by entering monitor DPI. Calibration persists in localStorage.

Useful for design / front-end work where you need to verify physical dimensions on screen. Open source: https://github.com/nasirazizawan009/keyboardtester-click