### PR TITLE
Add supercli to CLIs & Terminal Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [zx](https://github.com/google/zx) - Tool for writing shell scripts in JavaScript.
 * [ccr](https://github.com/NeverVane/commandchronicles) - Enhanced CLI history manager, project-aware, with sync and encryption.
 * [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets with dynamic completions and AI integration.
+- [supercli](https://github.com/javimosch/supercli) - Universal CLI router with 7,000+ plugins. One pattern for every tool, JSON-by-default output, agent-native discovery.
 
 ## DevOps & Infrastructure
 


### PR DESCRIPTION
Adds [supercli](https://github.com/javimosch/supercli) — universal CLI router with 7,000+ plugins. One command pattern for every tool, JSON-by-default output, agent-native discovery.

Fits the CLIs & Terminal Tools section as it provides unified access to 7,000+ developer tools through a single interface.