### PR TITLE
docs: add Payload Components CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [exa](https://the.exa.website/) - Modern replacement for `ls` with icons and colors.
 * [bat](https://github.com/sharkdp/bat) - Cat clone with syntax highlighting.
 * [zx](https://github.com/google/zx) - Tool for writing shell scripts in JavaScript.
+* [Payload Components](https://www.payload-components.xyz/) - CLI and registry for installing wired Payload CMS blocks into Payload v3 and Next.js projects.
 * [ccr](https://github.com/NeverVane/commandchronicles) - Enhanced CLI history manager, project-aware, with sync and encryption.
 * [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets with dynamic completions and AI integration.
 
@@ -162,4 +163,3 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 ---
 
 PRs welcome!
-


### PR DESCRIPTION
## Summary

Adds Payload Components as a developer resource for Payload CMS and Next.js projects.

Payload Components is an MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects.

## Validation

- Confirmed there was no existing Payload Components entry in this repository
- Confirmed there was no existing open Payload Components PR in this repository
- Ran `git diff --check`
- Confirmed `https://www.payload-components.xyz/` returns 200
