### PR TITLE
Add Gandr to APIs & Backends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
-* [Gandr](https://gandr.ai/) - Text to speech API for voice agents: 146 ms first audio byte, correct readback of numbers and dates, $10 per 1M characters, watermarked output.
+* [Gandr](https://gandr.ai/) - Text to speech API for voice agents: first audio byte in 146 ms over the open internet, correct readback of numbers and dates, $10/mo for 1M tokens, one voice in 23 languages, watermarked output.
 
 ## Design & UI Tools
 

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
+* [Gandr](https://gandr.ai/) - Text to speech API for voice agents: 146 ms first audio byte, correct readback of numbers and dates, $10 per 1M characters, watermarked output.
 
 ## Design & UI Tools
 

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
-* [Gandr](https://gandr.ai/) - Text to speech API for voice agents: transcription accuracy better than the human reference on the same scorer, correct readback of numbers and dates, $10/mo for 1M tokens, one voice in 23 languages, watermarked output.
+* [Gandr](https://gandr.ai/) - Text to speech API for voice agents: rendered speech scores a lower word error rate than the human reference on the same scorer, correct readback of numbers and dates, $10/mo for 1M tokens, one voice in 23 languages, watermarked output.
 
 ## Design & UI Tools
 

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ Inspired by [awesome](https://github.com/sindresorhus/awesome).
 * [Directus](https://directus.io/) - Real-time data platform and CMS.
 * [Postman](https://www.postman.com/) - All-in-one API platform for building and working with APIs.
 * [Hive Intelligence](https://hiveintelligence.xyz/) - Connect any AI agent to blockchain data through our standardized MCP protocol.
-* [Gandr](https://gandr.ai/) - Text to speech API for voice agents: first audio byte in 146 ms over the open internet, correct readback of numbers and dates, $10/mo for 1M tokens, one voice in 23 languages, watermarked output.
+* [Gandr](https://gandr.ai/) - Text to speech API for voice agents: transcription accuracy better than the human reference on the same scorer, correct readback of numbers and dates, $10/mo for 1M tokens, one voice in 23 languages, watermarked output.
 
 ## Design & UI Tools
 


### PR DESCRIPTION
Gandr is a text to speech API built for voice agents. First audio byte in 146 ms over the open internet, 116 ms p50 first audio server side warm, it reads numbers and dates correctly (the part that usually breaks phone bots), scores below the human reference on word error rate, and costs $10 per 1M tokens. Every render is watermarked. Fits this section as a backend API service. Happy to adjust the entry if you want a different format.

Disclosure: I work on Gandr.
